### PR TITLE
Fix database initialization promise handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -57,7 +57,15 @@ app.options("*", cors(corsOptions));
 
 /* ---------- Database ---------- */
 initDb()
-  .then(() => console.log("✅ Database initialized"))
+  .then((connection) => {
+    if (connection) {
+      console.log("✅ Database initialized");
+    } else {
+      console.warn(
+        "⚠️  Skipping database connection because process.env.DB is not configured."
+      );
+    }
+  })
   .catch((err) => {
     console.error("❌ Database init error:", err?.message || err);
     // Don't crash — app can still answer /healthz with failure state if needed


### PR DESCRIPTION
## Summary
- refactor the MongoDB initialisation helper to return a promise and guard against missing configuration
- improve database start-up logging and reuse of mongoose connection event listeners
- update the server bootstrap to log when the database is skipped instead of crashing on missing env vars

## Testing
- node server.js

------
https://chatgpt.com/codex/tasks/task_e_68cf1394717483249e87031b69691169