### PR TITLE
Update Fly launch config for machines

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -8,17 +8,20 @@ primary_region = "maa"
   NODE_ENV = "production"
   PORT = "8080"
 
-[[services]]
-  protocol = "tcp"
+[http_service]
   internal_port = 8080
+  force_https = true
+  auto_start_machines = true
+  auto_stop_machines = "stop"
+  min_machines_running = 0
+  processes = ["app"]
 
-  [[services.ports]]
+  [[http_service.ports]]
     port = 80
-  [[services.ports]]
+  [[http_service.ports]]
     port = 443
 
-  # HTTP health check
-  [[services.http_checks]]
+  [[http_service.checks]]
     interval = "15s"
     timeout = "3s"
     method = "get"

--- a/server.js
+++ b/server.js
@@ -57,7 +57,15 @@ app.options("*", cors(corsOptions));
 
 /* ---------- Database ---------- */
 initDb()
-  .then(() => console.log("✅ Database initialized"))
+  .then((connection) => {
+    if (connection) {
+      console.log("✅ Database initialized");
+    } else {
+      console.warn(
+        "⚠️  Skipping database connection because process.env.DB is not configured."
+      );
+    }
+  })
   .catch((err) => {
     console.error("❌ Database init error:", err?.message || err);
     // Don't crash — app can still answer /healthz with failure state if needed


### PR DESCRIPTION
## Summary
- switch the Fly configuration to the modern `http_service` stanza so launch plan generation recognises the Docker image
- keep the existing env defaults, ports and health check while enabling machine auto start/stop behaviour

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68cf1394717483249e87031b69691169