### PR TITLE
Fix Fly machines config options

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -8,17 +8,19 @@ primary_region = "maa"
   NODE_ENV = "production"
   PORT = "8080"
 
-[[services]]
-  protocol = "tcp"
+[http_service]
   internal_port = 8080
+  force_https = true
+  auto_start_machines = true
+  auto_stop_machines = true
+  min_machines_running = 0
 
-  [[services.ports]]
+  [[http_service.ports]]
     port = 80
-  [[services.ports]]
+  [[http_service.ports]]
     port = 443
 
-  # HTTP health check
-  [[services.http_checks]]
+  [[http_service.checks]]
     interval = "15s"
     timeout = "3s"
     method = "get"

--- a/server.js
+++ b/server.js
@@ -57,7 +57,15 @@ app.options("*", cors(corsOptions));
 
 /* ---------- Database ---------- */
 initDb()
-  .then(() => console.log("✅ Database initialized"))
+  .then((connection) => {
+    if (connection) {
+      console.log("✅ Database initialized");
+    } else {
+      console.warn(
+        "⚠️  Skipping database connection because process.env.DB is not configured."
+      );
+    }
+  })
   .catch((err) => {
     console.error("❌ Database init error:", err?.message || err);
     // Don't crash — app can still answer /healthz with failure state if needed


### PR DESCRIPTION
## Summary
- correct the Fly Machines auto stop flag to use the supported boolean form
- drop the redundant processes list in favour of the default container entrypoint

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68cf1394717483249e87031b69691169