### PR TITLE
Allow POS origin in CORS allowlist

### DIFF
--- a/server.js
+++ b/server.js
@@ -23,6 +23,7 @@ const allowList = new Set([
   "https://console.cul-ai.com",
   "https://cul-ai-frontend.fly.dev",
   "https://admin.cul-ai.com",
+  "https://pos.cul-ai.com",
   "http://localhost:3000",
   "http://localhost:3001",
   "https://main.d3m30tipkq4qvg.amplifyapp.com",


### PR DESCRIPTION
## Summary
- allow requests from the deployed POS interface at https://pos.cul-ai.com

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d00cc713748324af76f93243c2afab