### PR TITLE
Add console-culinks domain to CORS allow list

### DIFF
--- a/server.js
+++ b/server.js
@@ -21,6 +21,7 @@ app.set("trust proxy", true);
 /* ---------- CORS ---------- */
 const allowList = new Set([
   "https://console.cul-ai.com",
+  "https://console-culinks.vercel.app",
   "https://cul-ai-frontend.fly.dev",
   "https://admin.cul-ai.com",
   "https://pos.cul-ai.com",


### PR DESCRIPTION
## Summary
- add console-culinks.vercel.app to the CORS allowList so that it passes origin validation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d010614d848324ba80cd2cff267cd2